### PR TITLE
Remove body scrolling while scaling

### DIFF
--- a/app/src/main/java/ch/protonmail/android/activities/messageDetails/body/MessageBodyScaleListener.kt
+++ b/app/src/main/java/ch/protonmail/android/activities/messageDetails/body/MessageBodyScaleListener.kt
@@ -48,7 +48,6 @@ internal class MessageBodyScaleListener(private val wvScrollView:RecyclerView,
 		scaleFactor=Math.max(0.1f,Math.min(scaleFactor,10.0f))
 
 		val a=messageBodyWebView.scrollY
-		messageBodyWebView.scrollTo(0,0)
 		directParent.scrollTo(0,0)
 		messageInfoView.translationY=scaleFactor
 


### PR DESCRIPTION
**Describe the bug**
When reverse-pinch zooming within an email, the body view jumps to the upper left corner.

**To reproduce**
1. Open a lengthy email
2. Reverse-pinch zoom on a specific spot

**Expected behavior**
The zoom should target the reverse-pinch location.

**Screenshots**
![bug](https://user-images.githubusercontent.com/11410449/97097512-4ae1e100-163f-11eb-984c-8766415e36ab.gif)

**Smartphone (please complete the following information):**
Device: Pixel 3
OS: Android 11
Version 1.13.16