### PR TITLE
Removing broken repository

### DIFF
--- a/buildSrc/src/main/kotlin/repositories.kt
+++ b/buildSrc/src/main/kotlin/repositories.kt
@@ -26,5 +26,4 @@ import org.gradle.kotlin.dsl.maven
 val repos: RepositoryHandler.() -> Unit get() = {
     google()
     jcenter()
-    maven("https://dl.bintray.com/kotlin/kotlinx/")
 }


### PR DESCRIPTION
Unblock builds failing because of HTTP 502 errors from Bintray.