### PR TITLE
Bump playServices version to the latest

### DIFF
--- a/app/src/main/java/ch/protonmail/android/mailbox/presentation/ui/MailboxActivity.kt
+++ b/app/src/main/java/ch/protonmail/android/mailbox/presentation/ui/MailboxActivity.kt
@@ -1266,7 +1266,7 @@ internal class MailboxActivity :
                         PLAY_SERVICES_RESOLUTION_REQUEST
                     ) {
                         showToast("cancel", Toast.LENGTH_SHORT)
-                    }.show()
+                    }?.show()
                 }
             } else {
                 Timber.d("%s: This device is not GCM supported.", TAG_MAILBOX_ACTIVITY)

--- a/buildSrc/src/main/kotlin/versionsConfig.kt
+++ b/buildSrc/src/main/kotlin/versionsConfig.kt
@@ -88,7 +88,7 @@ const val `android-webkit version` =            "1.4.0"         // Released: Dec
 const val `flexbox version` =                   "2.0.1"         // Released: Jan 17, 2020
 const val `lifecycle-extensions version` =      "2.2.0"         // Released: Jan 22, 2020
 const val `googleServices version` =            "4.3.3"         // Released: Nov 11, 2019
-const val `playServices version` =              "17.0.0"        // Released: Jun 19, 2019
+const val `playServices version` =              "18.0.0"        // Released: Jun 28, 2022
 
 // Other
 const val `apache-commons-lang version` =       "3.4"           // Released: Apr 03, 2015


### PR DESCRIPTION
* After the recent 3.0.0 update, which included a bump to targetSdk 31,
  we've noticed some crashes when microG was disabled
* The stacktrace pointed to PendingIntent mutability flags, which are
  required for targetSdk 31

Some details with stacktrace: https://gitlab.com/CalyxOS/calyxos/-/issues/1056
Test: Install ProtonMail on a device with microG as a system app, and with it disabled
      Current stable release (3.0.2) will crash with the above stack trace
      A build with this patch will work fine