### PR TITLE
#Fix Adding content description to Expand / Collapse dropdown button …

### DIFF
--- a/app/src/main/java/ch/protonmail/android/views/messageDetails/MessageDetailsHeaderView.kt
+++ b/app/src/main/java/ch/protonmail/android/views/messageDetails/MessageDetailsHeaderView.kt
@@ -251,6 +251,9 @@ class MessageDetailsHeaderView @JvmOverloads constructor(
             } else {
                 expandHeader()
             }
+            it.contentDescription = context?.getString(
+                if (isExpanded) R.string.expand_message_details else R.string.collapse_message_details
+            ) ?: ""
             isExpanded = isExpanded.not()
         }
         expandedHeaderGroup.isVisible = false

--- a/app/src/main/res/layout/layout_message_details_header.xml
+++ b/app/src/main/res/layout/layout_message_details_header.xml
@@ -171,6 +171,7 @@
         android:padding="@dimen/message_details_header_chevron_icon_padding"
         app:srcCompat="@drawable/ic_proton_chevron_down"
         android:visibility="gone"
+        android:contentDescription="@string/expand_message_details"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/timeDateTextView"
         app:tint="@color/icon_weak"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -965,4 +965,7 @@
     <string name="could_not_complete_action">Could not complete the action</string>
 
     <string name="decryption_of_message_failed">Decryption error: decryption of this message\'s encrypted content failed.</string>
+
+    <string name="expand_message_details">Expand Message Details</string>
+    <string name="collapse_message_details">Collapse Message Details</string>
 </resources>


### PR DESCRIPTION
Fixed [bug](https://github.com/ProtonMail/proton-mail-android/issues/177)
Added content description(Only added English - Need translation) for dropdown expand/collapse button in Mail Details screen.

Affected: MessageDetailsHeaderView.kt