### PR TITLE
Add support for Themed App Icons in Android 13

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -21,4 +21,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -21,4 +21,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
### Light Mode:
<img src="https://user-images.githubusercontent.com/68556576/185776675-8956b9d2-4c5d-45ef-9f94-2e8141274e67.png" width="360">

### Dark Mode:
<img src="https://user-images.githubusercontent.com/68556576/185776652-7a52a4e7-5ff8-4d6e-9e8e-c1a855c70442.png" width="360">