### PR TITLE
Add monochrome icon for Android 13

### DIFF
--- a/app/src/beta/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/beta/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -21,4 +21,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/app/src/beta/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/beta/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -21,4 +21,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (c) 2022 Proton AG
+  ~
+  ~ This file is part of Proton Mail.
+  ~
+  ~ Proton Mail is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Proton Mail is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Proton Mail. If not, see https://www.gnu.org/licenses/.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group
+        android:scaleX="1.38"
+        android:scaleY="1.38"
+        android:translateX="32"
+        android:translateY="32">
+        <path
+            android:fillColor="#0C0C14"
+            android:fillType="evenOdd"
+            android:pathData="M30,7.003C30,5.3419 28.0917,4.4053 26.7776,5.4214L16.6115,13.2827C16.2514,13.5612 15.7486,13.5612 15.3885,13.2827L5.2224,5.4214C3.9083,4.4053 2,5.3419 2,7.003V22.9871C2,25.1955 3.7903,26.9858 5.9987,26.9858H26.0014C28.2097,26.9858 30,25.1955 30,22.9871V7.003ZM3.9993,9.9736V7.003L14.1655,14.8643C14.525,15.1423 14.9319,15.3278 15.3546,15.4208L14.3186,16.3477C13.662,16.9352 12.6766,16.9608 11.9903,16.4082L3.9993,9.9736ZM26.0014,24.9864H24.3662V9.8135L28.0007,7.003V22.9871C28.0007,24.0913 27.1055,24.9864 26.0014,24.9864Z" />
+    </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -21,4 +21,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -21,4 +21,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
This PR adds support for Android 13 themed icons. To accomplish this I used the vector asset that ProtonMail uses for notifications and modified the scale to fit the app icon requirements. If there is a better asset to use please let me know.

Issue: 
- #190 

Examples:
<img width="534" alt="image" src="https://user-images.githubusercontent.com/6266621/197633906-96e9dfff-7ceb-4965-af55-62597bbd6420.png">
<img width="534" alt="image" src="https://user-images.githubusercontent.com/6266621/197633938-361ec51f-b359-40d4-88a4-288fa33bdece.png">
<img width="535" alt="image" src="https://user-images.githubusercontent.com/6266621/197634043-037cb8c5-903e-4feb-864f-1fddef38bcf0.png">
<img width="536" alt="image" src="https://user-images.githubusercontent.com/6266621/197634090-4fde4e71-29b4-4142-9a01-248afcf8b567.png">
