### PR TITLE
Remove SQLite jdbc workaround needed for old versions of Room

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,16 +23,6 @@ buildscript {
     dependencies(classpathDependencies)
 }
 
-// Room 2.3 use a jdbc not compatible with arm so use the updated one to support
-// arm build. Room 2.4 should fix this issue (not stable yet)
-allprojects {
-    configurations.all {
-        resolutionStrategy {
-            force("org.xerial:sqlite-jdbc:3.34.0")
-        }
-    }
-}
-
 plugins {
     id("me.proton.kotlin") version "0.1" // Released: Oct 09, 2020
     id("me.proton.tests") version "0.1" // Released: Oct 09, 2020


### PR DESCRIPTION
I was exploring the project looking for a ways to contribute and the first thing that caught my attention was this old workaround for AndroidX Room that has no longer been needed for over a year at this point.

This workaround was needed only on M1 Apple machines otherwise the build would break.
Since the version 2.4 or so it is no longer needed. 

I see you have `2.4.3` already in your project and it's pretty safe to get rid of this workaround at this point.